### PR TITLE
fix: await template to complete loading

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -241,7 +241,7 @@ async function loadEager(doc) {
 
   const main = doc.querySelector('main');
   if (main) {
-    decorateTemplates(main);
+    await decorateTemplates(main);
     decorateMain(main);
     aggregateTabSectionsIntoComponents(main);
     document.body.classList.add('appear');


### PR DESCRIPTION
Otherwise loadLazy starts already while the template loads in parallel, causing a flicker and layout shift.

The reason is https://github.com/hlxsites/xsc-wknd-commerce/blob/main/templates/adventures/adventures.js#L43 where the `main` is set to `display: none`. 

The site is not functional anymore, because it requires the tabs being loaded.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--xsc-wknd-commerce--hlxsites.hlx.live/draft/beatbuzzer/climbing-new-zealand
- After: https://await-tmpl--xsc-wknd-commerce--hlxsites.hlx.live/draft/beatbuzzer/climbing-new-zealand
