### PR TITLE
hardcode mapping from new to old core backend

### DIFF
--- a/blocks/adventure-details/adventure-details.js
+++ b/blocks/adventure-details/adventure-details.js
@@ -73,7 +73,44 @@ export default async function decorate(block) {
             onClick: async () => {
               state.set('adding', true);
               try {
-                await addProductsToCart([{ ...next.values }]);
+                // TODO: remove hardcoding after demo
+                let selection = {
+                  ...next.values,
+                  sku: 10
+                };
+
+                selection.optionsUIDs.forEach((option, idx) => {
+                  let newValue = ''
+
+                  // Dorm
+                  if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zNw==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80Ng=='
+                  }
+                  // single
+                  else if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zOA==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80OQ=='
+                  }
+                  // double
+                  else if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zOQ==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC81Mg=='
+                  }
+                  // may
+                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80MA==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzNS8zNw=='
+                  }
+                  // june
+                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80MQ==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzNS80MA=='
+                  }
+                  // july
+                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80Mg==') {
+                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80Ng=='
+                  }
+                  else {
+                    console.warn('unknown option - cannot hardcode', option)
+                  }
+                });
+                await addProductsToCart([selection]);
               } catch (error) {
                 console.error('Error occurred while adding products to cart:', error);
               } finally {
@@ -111,7 +148,7 @@ export default async function decorate(block) {
         });
       },
       ShortDescription: (ctx) => {
-        const shortDescContent = ctx?.data?.shortDescription;        
+        const shortDescContent = ctx?.data?.shortDescription;
         const strippedString = shortDescContent.replace(/<[^>]+>/g, '').trim();
         if (!shortDescContent || !strippedString) return;
 
@@ -125,7 +162,7 @@ export default async function decorate(block) {
       Attributes: (ctx) => {
         const attributes = ctx?.data?.attributes;
         if (!attributes) return;
-        
+
         let list;
         list = generateListHTML(attributes);
         const [html, updateContent] = createAccordion('Product specs', list, false);

--- a/blocks/adventure-details/adventure-details.js
+++ b/blocks/adventure-details/adventure-details.js
@@ -75,41 +75,20 @@ export default async function decorate(block) {
               try {
                 // TODO: remove hardcoding after demo
                 let selection = {
-                  ...next.values,
-                  sku: 10
+                  ...next.values
                 };
-
+                const optionsMap = {
+                  'Y29uZmlndXJhYmxlLzE5Mi8zNw==': 'Y29uZmlndXJhYmxlLzUzOC80Ng==', // dorm
+                  'Y29uZmlndXJhYmxlLzE5Mi8zOA==': 'Y29uZmlndXJhYmxlLzUzOC80OQ==', // single
+                  'Y29uZmlndXJhYmxlLzE5Mi8zOQ==': 'Y29uZmlndXJhYmxlLzUzOC81Mg==', // double
+                  'Y29uZmlndXJhYmxlLzE5My80MA==': 'Y29uZmlndXJhYmxlLzUzNS8zNw==', // may
+                  'Y29uZmlndXJhYmxlLzE5My80MQ==': 'Y29uZmlndXJhYmxlLzUzNS80MA==', // june
+                  'Y29uZmlndXJhYmxlLzE5My80Mg==': 'Y29uZmlndXJhYmxlLzUzNS80Mw==' // july
+                };
                 selection.optionsUIDs.forEach((option, idx) => {
-                  let newValue = ''
-
-                  // Dorm
-                  if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zNw==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80Ng=='
-                  }
-                  // single
-                  else if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zOA==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80OQ=='
-                  }
-                  // double
-                  else if (option === 'Y29uZmlndXJhYmxlLzE5Mi8zOQ==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC81Mg=='
-                  }
-                  // may
-                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80MA==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzNS8zNw=='
-                  }
-                  // june
-                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80MQ==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzNS80MA=='
-                  }
-                  // july
-                  else if (option === 'Y29uZmlndXJhYmxlLzE5My80Mg==') {
-                    selection.optionsUIDs[idx] = 'Y29uZmlndXJhYmxlLzUzOC80Ng=='
-                  }
-                  else {
-                    console.warn('unknown option - cannot hardcode', option)
-                  }
+                  selection.optionsUIDs[idx] = optionsMap[option];
                 });
+                selection.sku = 10;
                 await addProductsToCart([selection]);
               } catch (error) {
                 console.error('Error occurred while adding products to cart:', error);

--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -13,7 +13,9 @@ export default async function decorate(block) {
   // Render Containers
   return provider.render(Cart, {
     routeEmptyCartCTA: () => '/',
-    routeProduct: (product) => `/products/${product.url.urlKey}/${product.sku}`,
+    // TODO: this needs to be fixed - it already does not redirect to adventures properly.
+    // But this is an example of _starting_ to map new sku back to old sku...
+    routeProduct: (product) => `/products/${product.url.urlKey}/${product.sku === '10' ? '11' : product.sku}`,
     routeCheckout: () => '/checkout',
   })(block);
 }


### PR DESCRIPTION
# TODO

* change hardcode links from cart/checkout to use "11" SKU (inverse map)
* add option map to any other products, simple or configurable, that will be used in demo

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/


